### PR TITLE
Removing experimental JS include code

### DIFF
--- a/vendor/assets/javascripts/conekta.js
+++ b/vendor/assets/javascripts/conekta.js
@@ -209,12 +209,6 @@
       var e, s;
       if (typeof key === 'string' && key.match(/^[a-zA-Z0-9_]*$/) && key.length >= 20 && key.length < 30) {
         publishable_key = key;
-        e = document.createElement('script');
-        e.type = 'text/javascript';
-        e.async = true;
-        e.src = 'https://s3.amazonaws.com/conektaapi_includes/' + publishable_key + '.js';
-        s = document.getElementsByTagName('script')[0];
-        s.parentNode.insertBefore(e, s);
       } else {
         Conekta._helpers.log('Unusable public key: ' + key);
       }


### PR DESCRIPTION
This code was from an experimental js file and causes js include 404 errors.  The code execution is unaffected, but it is misleading.
